### PR TITLE
Replace keyboard rotation shortcuts with dedicated rotation buttons

### DIFF
--- a/docs/user-guide.adoc
+++ b/docs/user-guide.adoc
@@ -114,10 +114,10 @@ You can permanently toggle the snap-to-grid behavior using the checkbox in the G
 |Select points and press kbd:[Delete] to remove their parent objects (with confirmation)
 
 |*Rotate Clockwise*
-|Select points and press kbd:[Ctrl+Right Arrow] to rotate 90° clockwise
+|Select points and click the +90° button in the control panel to rotate 90° clockwise
 
 |*Rotate Counter-clockwise*
-|Select points and press kbd:[Ctrl+Left Arrow] to rotate 90° counter-clockwise
+|Select points and click the -90° button in the control panel to rotate 90° counter-clockwise
 |===
 
 == Navigation Map
@@ -157,7 +157,7 @@ The navigation map is a miniature representation of the entire diagram that appe
 [TIP]
 The navigation map is especially useful for very large diagrams where it's easy to lose context of where you are in the overall structure.
 
-== Grid Functions
+== Grid and Control Functions
 
 [cols="1,3"]
 |===
@@ -171,6 +171,15 @@ The navigation map is especially useful for very large diagrams where it's easy 
 
 |*Grid Size*
 |Adjust the spacing between grid lines (smaller values provide finer control)
+
+|*Show Glue Points*
+|Toggle to display dotted lines between connected points
+
+|*+90° Button*
+|Rotate selected objects 90 degrees clockwise
+
+|*-90° Button*
+|Rotate selected objects 90 degrees counter-clockwise
 |===
 
 === Grid Snapping Controls
@@ -268,11 +277,6 @@ When moving multiple points, the first selected point will snap to the grid, and
 |kbd:[Delete]
 |Delete selected diagram objects
 
-|kbd:[Ctrl] + kbd:[Right Arrow]
-|Rotate selected objects 90° clockwise
-
-|kbd:[Ctrl] + kbd:[Left Arrow]
-|Rotate selected objects 90° counter-clockwise
 |===
 
 == Point Tooltips

--- a/src/features/canvas/components/DiagramCanvas.svelte
+++ b/src/features/canvas/components/DiagramCanvas.svelte
@@ -15,12 +15,12 @@
   import { diagramData } from '../../diagram/DiagramState';
   import { canvasInteraction } from '../../interaction/actions/canvasInteraction';
   import { resizable } from '../../interaction/actions/resizable';
-  import { resizeCanvas } from '../../../utils/canvas';
+  import { resizeCanvas } from '@/utils/canvas';
   import NavigationMap from '../../navigation/components/NavigationMap.svelte';
   import PolygonCheckbox from '../../objects/components/PolygonCheckbox.svelte';
   import PointTooltip from '../../tooltips/components/PointTooltip.svelte';
-  import type { MovePointsByDeltaData, Point2D } from '../../../core/models/types';
-  import type { PointModel } from '../../../core/models/PointModel';
+  import type { MovePointsByDeltaData, Point2D } from '@/core/models/types';
+  import type { PointModel } from '@/core/models/PointModel';
   import { serviceRegistry } from '@/services/ServiceRegistry';  
   import GluePointConnections from '../../gluepoints/components/GluePointConnections.svelte';
   import ConnectionCheckbox from '../../gluepoints/components/ConnectionCheckbox.svelte';

--- a/src/features/diagram/components/ConfigPanel.svelte
+++ b/src/features/diagram/components/ConfigPanel.svelte
@@ -7,17 +7,19 @@
   } from '../DiagramState';
   import { isLoading, updateStatus } from '../../ui/UIState';
   import { gridEnabled, gridSize } from '../../canvas/CanvasState';
-  import { CGMESVersion } from '../../../core/models/types';
-  import { AppConfig } from '../../../core/config/AppConfig';
-  import { serviceRegistry } from '../../../services/ServiceRegistry';
+  import { CGMESVersion } from '@/core/models/types';
+  import { AppConfig } from '@/core/config/AppConfig';
+  import { serviceRegistry } from '@/services/ServiceRegistry';
   import Button from '../../ui/base-components/Button.svelte';
   import Select from '../../ui/base-components/Select.svelte';
   import RadioGroup from '../../ui/base-components/RadioGroup.svelte';
   import Input from '../../ui/base-components/Input.svelte';
   import { showGluePoints } from '../../gluepoints/GluePointState';
+  import { interactionState } from '../../interaction/InteractionState';
   
   // Get service
   const diagramService = serviceRegistry.diagramService;
+  const objectService = serviceRegistry.objectService;
   
   // Props
   let { 
@@ -78,6 +80,25 @@
     // Just dispatch the current state - don't invert here
     // Let the parent component handle the state
     onToggleMap(showNavigationMap);
+  }
+
+  // Handle rotation button click
+  async function handleRotate(degrees: number) {
+    try {
+      // Check if any points are selected
+      const selectedPoints = $interactionState.selectedPoints;
+      if (selectedPoints.size === 0) {
+        updateStatus('No objects selected for rotation');
+        return;
+      }
+
+      const success = await objectService.rotateSelectedObjects(degrees);
+      if (success) {
+        updateStatus(`Rotated objects by ${degrees} degrees`);
+      }
+    } catch (error) {
+      updateStatus(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 </script>
 
@@ -161,6 +182,21 @@
       Show Glue Points
     </label>
   </div>
+
+  <div class="rotation-controls">
+    <Button
+            id="rotate-ccw"
+            label="-90°"
+            on:click={() => handleRotate(-90)}
+            disabled={loading}>
+    </Button>
+    <Button
+            id="rotate-cw"
+            label="+90°"
+            on:click={() => handleRotate(90)}
+            disabled={loading}>
+    </Button>
+  </div>
 </div>
 
 
@@ -236,5 +272,16 @@
     font-style: italic;
     color: #666;
     white-space: nowrap;
+  }
+
+  .rotation-controls {
+    display: flex;
+    gap: var(--spacing-md);
+    margin-left: auto;
+    align-items: center;
+  }
+
+  .rotation-controls button {
+    min-width: 60px;
   }
 </style>

--- a/src/features/gluepoints/components/ConnectionCheckbox.svelte
+++ b/src/features/gluepoints/components/ConnectionCheckbox.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import type { Point2D, ViewTransform } from '../../../core/models/types';
-    import { worldToScreen } from '../../../utils/geometry';
+    import type { Point2D, ViewTransform } from '@/core/models/types';
+    import { worldToScreen } from '@/utils/geometry';
     import { interactionState } from '../../interaction/InteractionState';
     import { shouldShowConnectionCheckbox, isConnectionChecked } from '../GluePointState';
     import { diagramData } from '../../diagram/DiagramState';
-    import { serviceRegistry } from '../../../services/ServiceRegistry';
+    import { serviceRegistry } from '@/services/ServiceRegistry';
     
     // Props
     const { viewTransform } = $props<{ viewTransform: ViewTransform }>();

--- a/src/features/gluepoints/components/GluePointConnections.svelte
+++ b/src/features/gluepoints/components/GluePointConnections.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { ViewTransform } from '../../../core/models/types';
-  import { worldToScreen } from '../../../utils/geometry';
+  import type { ViewTransform } from '@/core/models/types';
+  import { worldToScreen } from '@/utils/geometry';
   import { diagramData } from '../../diagram/DiagramState';
   import { showGluePoints, getVisibleGlueConnections } from '../GluePointState';
   

--- a/src/features/navigation/components/NavigationMap.svelte
+++ b/src/features/navigation/components/NavigationMap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onMount, onDestroy } from 'svelte';
-    import type { DiagramModel } from '../../../core/models/DiagramModel';
-    import type { ViewTransform } from '../../../core/models/types';
+    import type { DiagramModel } from '@/core/models/DiagramModel';
+    import type { ViewTransform } from '@/core/models/types';
     import { canvasService } from '../../canvas/CanvasService';
     
     // Props

--- a/src/features/objects/components/PolygonCheckbox.svelte
+++ b/src/features/objects/components/PolygonCheckbox.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import type { Point2D, ViewTransform } from '../../../core/models/types';
+    import type { Point2D, ViewTransform } from '@/core/models/types';
     import type { DiagramObjectModel } from '../../../core/models/DiagramModel';
-    import { worldToScreen } from '../../../utils/geometry';
-    import { serviceRegistry } from '../../../services/ServiceRegistry';
+    import { worldToScreen } from '@/utils/geometry';
+    import { serviceRegistry } from '@/services/ServiceRegistry';
     
     // Props
     export let object: DiagramObjectModel;

--- a/src/features/tooltips/components/PointTooltip.svelte
+++ b/src/features/tooltips/components/PointTooltip.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import type { PointModel } from '../../../core/models/PointModel';
-  import type { ViewTransform, Point2D } from '../../../core/models/types';
-  import { worldToScreen } from '../../../utils/geometry';
-  import { serviceRegistry } from '../../../services/ServiceRegistry';
+  import type { PointModel } from '@/core/models/PointModel';
+  import type { ViewTransform, Point2D } from '@/core/models/types';
+  import { worldToScreen } from '@/utils/geometry';
+  import { serviceRegistry } from '@/services/ServiceRegistry';
   
   // Props
   let { 


### PR DESCRIPTION
Add +90° and -90° rotation buttons to the control panel since Ctrl+Arrow keys are now used for object movement. Update documentation accordingly.